### PR TITLE
Fix known issues for KeyBindSystem

### DIFF
--- a/CommonAPI/Systems/KeyBindSystem/Patches/Chainloader_Patch.cs
+++ b/CommonAPI/Systems/KeyBindSystem/Patches/Chainloader_Patch.cs
@@ -12,21 +12,41 @@ namespace CommonAPI.Patches
 {
     public static class Chainloader_Patch
     {
-        public delegate T2 RefAction<T, out T2>(ref T arg);
+        private const int OverrideKeysNewSize = 512;
+
+        private delegate T2 RefAction<T, out T2>(ref T arg);
 
 
         [HarmonyPatch(typeof(GameOption), nameof(GameOption.ImportXML))]
         [HarmonyPrefix]
         public static void AfterAllLoaded()
         {
+            // Resize overrideKeys and overrideKeysChanged arrays to new size, to prevent out of bounds exceptions
+            Array.Resize(ref VFInput.override_keys, OverrideKeysNewSize);
+            Array.Resize(ref DSPGame.globalOption.overrideKeys, OverrideKeysNewSize);
+            Array.Resize(ref DSPGame.globalOption.overrideKeysChanged, OverrideKeysNewSize);
+
             CommonAPIPlugin.logger.LogDebug("Loading config file");
-            string path = $"{Paths.ConfigPath}/CommonAPI/keybindmapping";
+            string path = $"{Paths.ConfigPath}/CommonAPI/keybinds";
+            try
+            {
+                FileStream stream = File.OpenRead(path);
+                BinaryReader reader = new BinaryReader(stream);
+                CustomKeyBindSystem.Import(reader);
+                stream.Dispose();
+                return;
+            }
+            catch (Exception)
+            {
+                CommonAPIPlugin.logger.LogDebug("keybinds not found, fallbacking to load legacy keybindmapping");
+            }
+            path = $"{Paths.ConfigPath}/CommonAPI/keybindmapping";
             try
             {
                 FileStream stream = File.OpenRead(path);
                 BinaryReader reader = new BinaryReader(stream);
                 CustomKeyBindSystem.keyRegistry.Import(reader);
-                stream.Close();
+                stream.Dispose();
             }
             catch (Exception)
             {
@@ -34,18 +54,51 @@ namespace CommonAPI.Patches
             }
         }
 
-        [HarmonyPatch(typeof(GameOption), nameof(GameOption.ImportXML))]
+        [HarmonyPatch(typeof(GameOption), nameof(GameOption.Apply))]
         [HarmonyPostfix]
-        public static void OnLoadXML()
+        public static void SaveKeyBindsOnApplyOptions()
         {
             CommonAPIPlugin.logger.LogDebug("saving config file");
             Directory.CreateDirectory($"{Paths.ConfigPath}/CommonAPI/");
-            string path = $"{Paths.ConfigPath}/CommonAPI/keybindmapping";
-            FileStream stream = File.Open(path, FileMode.Create);
+            string path = $"{Paths.ConfigPath}/CommonAPI/keybinds";
+            FileStream stream = File.Create(path);
             BinaryWriter writer = new BinaryWriter(stream);
 
-            CustomKeyBindSystem.keyRegistry.Export(writer);
-            stream.Close();
+            CustomKeyBindSystem.Export(writer);
+            stream.Dispose();
+        }
+
+	// Search for loading 256 and replace it with new size
+        [HarmonyPatch(typeof(GameOption), nameof(GameOption.InitKeys))]
+        [HarmonyTranspiler]
+        public static IEnumerable<CodeInstruction> PatchInitKeys(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            CodeMatcher matcher = new CodeMatcher(instructions, generator)
+                .MatchForward(false,
+                    new CodeMatch(OpCodes.Ldc_I4, 256));
+            matcher.Set(OpCodes.Ldc_I4, OverrideKeysNewSize);
+            return matcher.InstructionEnumeration();
+        }
+
+        // Search for:
+        //   int num = 256;
+        //   this.tempOption.overrideKeys = new CombineKey[num];
+        // Set `num` to new size
+        [HarmonyPatch(typeof(UIOptionWindow), nameof(UIOptionWindow._OnOpen))]
+        [HarmonyTranspiler]
+        public static IEnumerable<CodeInstruction> PatchOverrideKeysLength(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            CodeMatcher matcher = new CodeMatcher(instructions, generator)
+                .MatchForward(false,
+                    new CodeMatch(OpCodes.Ldc_I4),
+                    new CodeMatch(ci => ci.IsStloc()),
+                    new CodeMatch(OpCodes.Ldarg_0),
+                    new CodeMatch(OpCodes.Ldflda, AccessTools.Field(typeof(UIOptionWindow), nameof(UIOptionWindow.tempOption))),
+                    new CodeMatch(ci => ci.IsLdloc()),
+                    new CodeMatch(OpCodes.Newarr, typeof(CombineKey))
+                );
+            matcher.Set(OpCodes.Ldc_I4, OverrideKeysNewSize);
+            return matcher.InstructionEnumeration();
         }
 
         [HarmonyPatch(typeof(GameOption), nameof(GameOption.ImportXML))]
@@ -92,6 +145,32 @@ namespace CommonAPI.Patches
                 }))
                 .InsertAndAdvance(new CodeInstruction(OpCodes.Brfalse, label));
 
+
+            return matcher.InstructionEnumeration();
+        }
+
+        // Do not save overrideKeys with id >= 256 to options.xml
+        //  Search for:
+        //   int num2 = this.overrideKeys.Length;
+        //  Replace with:
+        //   int num2 = Math.Min(this.overrideKeys.Length, 256);
+        [HarmonyPatch(typeof(GameOption), nameof(GameOption.ExportXML))]
+        [HarmonyTranspiler]
+        public static IEnumerable<CodeInstruction> FixOverrideKeysExport(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            CodeMatcher matcher = new CodeMatcher(instructions, generator)
+                .MatchForward(true,
+                    new CodeMatch(OpCodes.Ldarg_0),
+                    new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(GameOption), nameof(GameOption.overrideKeys))),
+                    new CodeMatch(OpCodes.Ldlen),
+                    new CodeMatch(OpCodes.Conv_I4),
+                    new CodeMatch(ci => ci.IsStloc())
+                );
+
+            matcher.InsertAndAdvance(
+                new CodeInstruction(OpCodes.Ldc_I4, 256),
+                new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(Math), nameof(Math.Min), new[] { typeof(int), typeof(int) }))
+            );
 
             return matcher.InstructionEnumeration();
         }

--- a/CommonAPI/Util/Data/Registry.cs
+++ b/CommonAPI/Util/Data/Registry.cs
@@ -59,7 +59,7 @@ namespace CommonAPI
         /// <returns></returns>
         public int Register(string key, object item = null)
         {
-            if (!idMap.ContainsKey(key))
+            if (!idMap.TryGetValue(key, out var id))
             {
                 OnItemRegistered(key, lastId + 1, item);
                 idMap.Add(key, ++lastId);
@@ -71,7 +71,7 @@ namespace CommonAPI
                 throw new InvalidOperationException($"Failed to register object with key '{key}', because it is taken!");
             }
 
-            return GetUniqueId(key);
+            return id;
         }
 
         /// <summary>
@@ -82,8 +82,8 @@ namespace CommonAPI
         /// <exception cref="ArgumentException">Thrown if requested string ID was never registered</exception>
         public int GetUniqueId(string typeId)
         {
-            if (idMap.ContainsKey(typeId))
-                return idMap[typeId];
+            if (idMap.TryGetValue(typeId, out var id))
+                return id;
             
             throw new ArgumentException($"Item with id {typeId} is not registered!");
         }
@@ -95,12 +95,7 @@ namespace CommonAPI
         /// <returns></returns>
         public int MigrateId(int oldId)
         {
-            if (migrationMap.ContainsKey(oldId))
-            {
-                return migrationMap[oldId];
-            }
-
-            return 0;
+            return migrationMap.TryGetValue(oldId, out var newId) ? newId : 0;
         }
 
         public void Free()


### PR DESCRIPTION
1. Fix conflict with latest game update.
    The maxium `CombineKey` id from original game is 104 now, so the new codes set startId to 256 to avoid possible conflicts (at present and in future), and resize arrays to 512.
2. Fix possible key-id mismatches while switch profiles with mod management tools.
    Now saves key binds data (keyCode+modifier+action+noneKey) to a custom option file.

I also replaced `Contains()` with `TryGetValue()` in `Registry` class to improve performance.