### PR TITLE
Fixed an issue that key configs are not read correctly.

### DIFF
--- a/CommonAPI/Systems/KeyBindSystem/Patches/Chainloader_Patch.cs
+++ b/CommonAPI/Systems/KeyBindSystem/Patches/Chainloader_Patch.cs
@@ -68,16 +68,12 @@ namespace CommonAPI.Patches
             stream.Dispose();
         }
 
-	// Search for loading 256 and replace it with new size
+        // Skip GameOption.InitKeys() to avoid reset of GameOption.overrideKeys.
         [HarmonyPatch(typeof(GameOption), nameof(GameOption.InitKeys))]
-        [HarmonyTranspiler]
-        public static IEnumerable<CodeInstruction> PatchInitKeys(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        [HarmonyPrefix]
+        public static bool PatchInitKeys()
         {
-            CodeMatcher matcher = new CodeMatcher(instructions, generator)
-                .MatchForward(false,
-                    new CodeMatch(OpCodes.Ldc_I4, 256));
-            matcher.Set(OpCodes.Ldc_I4, OverrideKeysNewSize);
-            return matcher.InstructionEnumeration();
+            return false;
         }
 
         // Search for:


### PR DESCRIPTION
`GameOption.InitKeys()` is inside call-chain in `GameOption.ImportXML()` so that loaded key configs in prefix patch are reset.
This PR fixes this issue by skipping `GameOption.InitKeys()` (We initialized key lists in prefix patch already).